### PR TITLE
Potential fix for code scanning alert no. 3: Information exposure through an exception

### DIFF
--- a/api/sfm_api.py
+++ b/api/sfm_api.py
@@ -171,7 +171,10 @@ async def get_quick_analysis(service: SFMService = Depends(get_sfm_service_depen
     
     Returns summary statistics, health status, and top central nodes.
     """
-    return quick_analysis(service)
+    result = quick_analysis(service)
+    if "error" in result:
+        raise HTTPException(status_code=500, detail=result["error"])
+    return result
 
 @app.get("/analytics/centrality", response_model=CentralityAnalysis, tags=["Analytics"])
 async def analyze_centrality(

--- a/core/sfm_service.py
+++ b/core/sfm_service.py
@@ -1256,5 +1256,5 @@ def quick_analysis(service: SFMService) -> Dict[str, Any]:
             "analysis_timestamp": datetime.now().isoformat(),
         }
     except Exception as e:
-        logger.error("Quick analysis failed: %s", e)
-        return {"error": str(e), "analysis_timestamp": datetime.now().isoformat()}
+        logger.error("Quick analysis failed: %s", e, exc_info=True)
+        return {"error": "An internal error occurred. Please try again later.", "analysis_timestamp": datetime.now().isoformat()}


### PR DESCRIPTION
Potential fix for [https://github.com/SFM-Graph-Service/alpha/security/code-scanning/3](https://github.com/SFM-Graph-Service/alpha/security/code-scanning/3)

To fix the issue, we will modify the `quick_analysis` function in `core/sfm_service.py` to log the exception details on the server side and return a generic error message to the user. This ensures that sensitive information is not exposed in the API response. Additionally, we will update the `/analytics/quick` endpoint in `api/sfm_api.py` to handle the modified return structure of `quick_analysis`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
