### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,6 +2,9 @@ name: Pylint
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/SFM-Graph-Service/alpha/security/code-scanning/1](https://github.com/SFM-Graph-Service/alpha/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root of the workflow file. This block will explicitly define the permissions required for the workflow. Since the workflow only needs to read repository contents to perform linting, the `contents: read` permission is sufficient. This change ensures that the workflow does not inadvertently gain unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
