### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,5 +1,8 @@
 name: Run Pytest with Coverage
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/SFM-Graph-Service/alpha/security/code-scanning/4](https://github.com/SFM-Graph-Service/alpha/security/code-scanning/4)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the minimal permissions required for the workflow to function. Based on the actions performed in the workflow, the `contents: read` permission is sufficient. This permission allows the workflow to read repository contents without granting write access.

The `permissions` block can be added at the root level of the workflow file to apply to all jobs, or it can be added specifically to the `test` job. In this case, adding it at the root level is recommended for simplicity and consistency.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
